### PR TITLE
Fixed the Documentation Bug

### DIFF
--- a/iportal/views.py
+++ b/iportal/views.py
@@ -80,7 +80,7 @@ class ApplicantOrganisationViewset(ModelViewSet):
     queryset = ApplicantOrganisation.objects.all()
     serializer_class = ApplicantOrganisationSerializer
     filter_backends = (filters.DjangoFilterBackend,)
-    filterset_fields = ('applicant','organisation_name','role')    
+    filterset_fields = ('applicant','organisation','role')    
     pagination_class = GeneralPagination
 
 class ApplicantProjectViewset(ModelViewSet):

--- a/server/settings.py
+++ b/server/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'users',
     'rest_framework',
+    'rest_framework_swagger',
     'events',
     'sponsors',
     'mentors',

--- a/server/urls.py
+++ b/server/urls.py
@@ -8,6 +8,10 @@ from django.conf.urls.static import static
 from django.conf import settings
 from android_app.views import latest_build
 
+## for swagger apis
+from rest_framework_swagger.views import get_swagger_view
+schema_view = get_swagger_view(title='ECell Web API Documentation', url='/swagger')
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('users/', include('users.urls')),
@@ -24,6 +28,7 @@ urlpatterns = [
     path('iportal/', include('iportal.urls')),
     path('investors/', include('investors.urls')),
     path('summernote/', include('django_summernote.urls')),
+    path('api/', schema_view),
 ]
 urlpatterns+=staticfiles_urlpatterns()
 # for the media urls


### PR DESCRIPTION
The documentation is now live at website/api/

The bug aroused do to incorrect field name in a viewset belonging to Iportal App

The documentation link worked correctly on a linux 18.04